### PR TITLE
🚑 !HOTFIX: group by 없이 집계함수를 사용하는 부분 수정

### DIFF
--- a/src/main/java/com/fanmix/api/domain/review/repository/ReviewQuerydslRepositoryImpl.java
+++ b/src/main/java/com/fanmix/api/domain/review/repository/ReviewQuerydslRepositoryImpl.java
@@ -27,6 +27,7 @@ public class ReviewQuerydslRepositoryImpl implements ReviewQuerydslRepository {
 			.join(review.influencer, influencer).fetchJoin()
 			.join(review.member, member).fetchJoin()
 			.where(review.isDeleted.eq(false))
+			.groupBy(review.id)
 			.orderBy(sort(sort))
 			.fetch();
 	}
@@ -37,6 +38,7 @@ public class ReviewQuerydslRepositoryImpl implements ReviewQuerydslRepository {
 			.leftJoin(review.reviewLikeDislikes, reviewLikeDislike)
 			.join(review.member, member).fetchJoin()
 			.where(review.isDeleted.eq(false), review.influencer.eq(influencer))
+			.groupBy(review.id)
 			.orderBy(sort(sort))
 			.fetch();
 	}


### PR DESCRIPTION
## Motivation

🚑 !HOTFIX: group by 없이 집계함수를 사용하는 부분 수정한걸 배포 위해 main 에 머지

## Key Changes

- Change 1
  - f03b531e107e40f78b5a8716366c2a74a0c62fb6: 리뷰를 좋아요 - 싫어요 순으로 정렬할 때 group by 없이 사용하여 에러 발생하는 부분을 .groupBy(review.id) 를 붙여 수정

## To reviewers
급하게 하다보니 실수를 했습니다 죄송합니다.
