### PR TITLE
🚑 !HOTFIX: 리뷰 좋아요 눌렀는지 판독할 때 실수 수정

### DIFF
--- a/src/main/java/com/fanmix/api/domain/review/repository/ReviewLikeDislikeRepository.java
+++ b/src/main/java/com/fanmix/api/domain/review/repository/ReviewLikeDislikeRepository.java
@@ -16,5 +16,5 @@ public interface ReviewLikeDislikeRepository extends JpaRepository<ReviewLikeDis
 
 	Boolean existsByReviewAndMember(Review review, Member member);
 
-	Optional<ReviewLikeDislike> findByMember(Member member);
+	Optional<ReviewLikeDislike> findByMemberAndReview(Member member, Review review);
 }

--- a/src/main/java/com/fanmix/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fanmix/api/domain/review/service/ReviewService.java
@@ -227,7 +227,8 @@ public class ReviewService {
 
 			if (member != null) {
 				isMyReview = member.getId() == reviewer.getId();
-				Optional<ReviewLikeDislike> reviewLikeOrDislike = reviewLikeDislikeRepository.findByMember(member);
+				Optional<ReviewLikeDislike> reviewLikeOrDislike =
+					reviewLikeDislikeRepository.findByMemberAndReview(member, review);
 
 				if (reviewLikeOrDislike.isPresent()) {
 					isLiked = reviewLikeOrDislike.get().getIsLike();
@@ -294,7 +295,8 @@ public class ReviewService {
 
 			if (member != null) {
 				isMyReview = member.getId() == reviewer.getId();
-				Optional<ReviewLikeDislike> reviewLikeOrDislike = reviewLikeDislikeRepository.findByMember(member);
+				Optional<ReviewLikeDislike> reviewLikeOrDislike =
+					reviewLikeDislikeRepository.findByMemberAndReview(member, review);
 
 				if (reviewLikeOrDislike.isPresent()) {
 					isLiked = reviewLikeOrDislike.get().getIsLike();
@@ -344,7 +346,8 @@ public class ReviewService {
 			boolean isLiked = false;
 			boolean isDisliked = false;
 
-			Optional<ReviewLikeDislike> reviewLikeOrDislike = reviewLikeDislikeRepository.findByMember(member);
+			Optional<ReviewLikeDislike> reviewLikeOrDislike =
+				reviewLikeDislikeRepository.findByMemberAndReview(member, review);
 			if (reviewLikeOrDislike.isPresent()) {
 				isLiked = reviewLikeOrDislike.get().getIsLike();
 				isDisliked = !isLiked;
@@ -376,7 +379,8 @@ public class ReviewService {
 			boolean isDisliked = false;
 
 			if (member != null) {
-				Optional<ReviewLikeDislike> reviewLikeOrDislike = reviewLikeDislikeRepository.findByMember(member);
+				Optional<ReviewLikeDislike> reviewLikeOrDislike =
+					reviewLikeDislikeRepository.findByMemberAndReview(member, review);
 
 				if (reviewLikeOrDislike.isPresent()) {
 					isLiked = reviewLikeOrDislike.get().getIsLike();


### PR DESCRIPTION
## Motivation

회원이 리뷰에 좋아요를 눌렀는지 여부를 파악할 때
findByMemberAndReview 여야 하는데 findByMember 로 들어가 있어서 오류 발생한 부분 수정


## Key Changes

- Change 1
  - e7faabd8229ec722262f042c717dbf1453ca211e: findByMember -> findByMemberAndReview

## To reviewers

