### PR TITLE
fix : 백엔드에 없는 api를 호출했을 경우 로그인 여부에 상관없이 404로 응답하도록 수정

### DIFF
--- a/src/main/java/com/fanmix/api/common/conf/SecurityConfig.java
+++ b/src/main/java/com/fanmix/api/common/conf/SecurityConfig.java
@@ -115,7 +115,7 @@ public class SecurityConfig {
 				.permitAll()
 
 				.anyRequest()
-				.authenticated()
+				.permitAll()
 			)
 			//.formLogin(form -> form    //formLogin은 로그인정보를 처리하는 기능까지 포함
 			// 	.loginPage("/login")        //loginPage는 로그인정보를 입력하는 페이지만 제공

--- a/src/main/java/com/fanmix/api/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/fanmix/api/common/exception/CommonErrorCode.java
@@ -15,7 +15,8 @@ public enum CommonErrorCode implements ErrorCode {
 	COMMON_RESOURCE_NOT_FOUND(NOT_FOUND, "0-003", "요청한 리소스를 찾을 수 없습니다. 요청한 URL에 해당하는 리소스가 없거나 삭제되었을 수 있습니다."),
 	METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "0-004", null), // 여기서는 메시지가 핸들러에서 만들어짐
 	SENDING_MAIL_FAIL(INTERNAL_SERVER_ERROR, "0-005", "메일 전송이 서버 문제로 실패했습니다."),
-	INVALID_REQUEST(BAD_REQUEST, "0-006", "데이터 요청 형식이 올바르지 않습니다.");
+	INVALID_REQUEST(BAD_REQUEST, "0-006", "데이터 요청 형식이 올바르지 않습니다."),
+	INVALID_API(NOT_FOUND, "0-007", "요청한 API는 없는 API입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String customCode;

--- a/src/main/java/com/fanmix/api/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/fanmix/api/common/exception/CommonExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.fanmix.api.common.response.Response;
@@ -76,6 +77,13 @@ public class CommonExceptionHandler {
 		log.error("[MaxUploadSizeExceededException] Message: {}", ex.getMessage());
 		return ResponseEntity.badRequest()
 			.body(Response.fail(EXCEED_MAX_SIZE_IMAGE_FILE.getCustomCode(), EXCEED_MAX_SIZE_IMAGE_FILE.getMessage()));
+	}
+
+	@ExceptionHandler(value = NoHandlerFoundException.class)
+	public ResponseEntity<Response<String>> handleNoHandlerFoundException(Exception ex) {
+		log.error("[Exception] Message: {}", ex.getMessage(), ex);
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)  // 404 상태 코드로 변경
+			.body(Response.fail(INVALID_API.getCustomCode(), INVALID_API.getMessage()));
 	}
 
 	@ExceptionHandler(value = Exception.class)


### PR DESCRIPTION
application.yml파일도 수정해서 배포해줘야함.

spring: 하위에
  mvc:
    throw-exception-if-no-handler-found: true #스프링MVC가 요청을 처리할 컨트롤러를 찾지 못했을때 NoHandlerFoundException을 던지도록 함
  web:
    resources:
      add-mappings: false # 기본 리소스 핸들러 매핑을 비활성화
추가해줘야함
