### PR TITLE
🐛  fix: 팬채널 정보/글/댓글 관련 권한 처리 로직 팬일 경우만 작업 가능하도록 수정

### DIFF
--- a/src/main/java/com/fanmix/api/domain/community/service/FanChannelService.java
+++ b/src/main/java/com/fanmix/api/domain/community/service/FanChannelService.java
@@ -87,11 +87,10 @@ public class FanChannelService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(!member.getRole().equals(Role.COMMUNITY)) {
-			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
-		}
 		Community community = communityRepository.findById(communityId)
 				.orElseThrow(() -> new CommunityException(CommunityErrorCode.COMMUNITY_NOT_EXIST));
+
+		if(communityId <= 12) throw new CommunityException(CommunityErrorCode.NOT_A_FANCHANNEL);
 
 		Boolean isFan = fanRepository.existsByInfluencerAndMember(community.getInfluencer(), member);
 		return new FanChannelResponse(community, isFan);

--- a/src/main/java/com/fanmix/api/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/fanmix/api/domain/post/dto/PostListResponse.java
@@ -22,10 +22,11 @@ public class PostListResponse {
 	private int likeCount;
 	private int dislikeCount;
 	private int commentCount;
+	private Boolean isEditable;
 	private LocalDateTime crDate;
 	private LocalDateTime uDate;
 
-	public PostListResponse(Post post, boolean isMyPosts) {
+	public PostListResponse(Post post, boolean isMyPosts, boolean isEditable) {
 		this.communityId = post.getCommunity().getId();
 		this.communityName = post.getCommunity().getName();
 		this.influencerId = post.getCommunity().getInfluencer() == null ? 0 : post.getCommunity().getInfluencer().getId();
@@ -43,5 +44,6 @@ public class PostListResponse {
 		this.crDate = post.getCrDate();
 		this.uDate = post.getUDate();
 		this.isMyPosts = isMyPosts;
+		this.isEditable = isEditable;
 	}
 }

--- a/src/main/java/com/fanmix/api/domain/post/service/FanChannelPostService.java
+++ b/src/main/java/com/fanmix/api/domain/post/service/FanChannelPostService.java
@@ -1,11 +1,11 @@
 package com.fanmix.api.domain.post.service;
 
 import com.fanmix.api.common.image.service.ImageService;
-import com.fanmix.api.domain.common.Role;
 import com.fanmix.api.domain.community.entity.Community;
 import com.fanmix.api.domain.community.exception.CommunityErrorCode;
 import com.fanmix.api.domain.community.exception.CommunityException;
 import com.fanmix.api.domain.community.repository.CommunityRepository;
+import com.fanmix.api.domain.fan.repository.FanRepository;
 import com.fanmix.api.domain.influencer.entity.Influencer;
 import com.fanmix.api.domain.influencer.exception.InfluencerErrorCode;
 import com.fanmix.api.domain.influencer.exception.InfluencerException;
@@ -41,6 +41,7 @@ public class FanChannelPostService {
 	private final PostLikeDisLikeRepository postLikeDisLikeRepository;
 	private final ImageService imageService;
 	private final InfluencerRepository influencerRepository;
+	private final FanRepository fanRepository;
 
 	// 팬채널 글 추가
 	@Transactional
@@ -55,8 +56,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if (!member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(community.getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		Post post = request.toEntity(community, member);
@@ -87,8 +88,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(!member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(community.getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		Sort likeCountDesc = Sort.by(
@@ -121,8 +122,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(post.getCommunity().getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		return new PostDetailResponse(post,  post.getMember().getId() == member.getId());
@@ -137,8 +138,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 				.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(!member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(post.getCommunity().getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		if(image != null && !image.isEmpty()) {
@@ -162,8 +163,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(!member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(post.getCommunity().getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 		post.updateByIsDelete();
 	}
@@ -177,8 +178,8 @@ public class FanChannelPostService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MemberErrorCode.NO_USER_EXIST));
 
-		if(!member.getRole().equals(Role.COMMUNITY)) {
-			throw new PostException(PostErrorCode.NOT_EXISTS_AUTHORIZATION);
+		if(!fanRepository.existsByInfluencerAndMember(post.getCommunity().getInfluencer(), member)) {
+			throw new CommunityException(CommunityErrorCode.NOT_EXISTS_AUTHORIZATION);
 		}
 
 		if(!postLikeDisLikeRepository.existsByMemberAndPost(member, post)) {

--- a/src/main/java/com/fanmix/api/domain/post/service/FanChannelPostService.java
+++ b/src/main/java/com/fanmix/api/domain/post/service/FanChannelPostService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -109,7 +110,8 @@ public class FanChannelPostService {
 
 		return postList
 			.stream()
-			.map(post -> new PostListResponse(post, post.getMember().getId() == member.getId()))
+			.map(post -> new PostListResponse(post, post.getMember().getId() == member.getId(),
+					post.getCrDate().isAfter(LocalDateTime.now().minusHours(3))))
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/fanmix/api/domain/post/service/PostService.java
+++ b/src/main/java/com/fanmix/api/domain/post/service/PostService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -98,7 +99,8 @@ public class PostService {
 
 		return postList
 			.stream().filter(post -> !post.isDelete())
-			.map(post -> new PostListResponse(post, member != null && post.getMember().getId() == member.getId()))
+			.map(post -> new PostListResponse(post, member != null && post.getMember().getId() == member.getId(),
+					post.getCrDate().isAfter(LocalDateTime.now().minusHours(3))))
 			.collect(Collectors.toList());
 	}
 
@@ -127,7 +129,8 @@ public class PostService {
 
 		return postList
 			.stream().filter(post -> !post.isDelete())
-			.map(post -> new PostListResponse(post, member != null && post.getMember().getId() == member.getId()))
+			.map(post -> new PostListResponse(post, member != null && post.getMember().getId() == member.getId(),
+					post.getCrDate().isAfter(LocalDateTime.now().minusHours(3))))
 			.collect(Collectors.toList());
 	}
 
@@ -260,7 +263,8 @@ public class PostService {
 				.map(post -> {
 					boolean isMyPosts = postRepository.existsByMember(member);
 					if(member == null) isMyPosts = false;
-					return new PostListResponse(post, isMyPosts);
+					boolean isEditable = post.getCrDate().isAfter(LocalDateTime.now().minusHours(3));
+					return new PostListResponse(post, isMyPosts, isEditable);
 				})
 				.collect(Collectors.toList());
 	}


### PR DESCRIPTION
## Motivation

<!-- 작업한 내용에 대한 설명을 자세히 적으세요 -->

팬채널 정보/글/댓글 관련 권한 처리 로직 팬일 경우만 작업 가능하도록 수정

## Key Changes

<!-- 작업한 내용의 주요 변경사항을 자세히 나열하세요 -->

- Change 1
  - 팬채널 정보 조회 불필요한 권한 처리 삭제, 팬채널이 아닐시 예외 처리
- Change 2
  - 팬채널 글 관련 권한 처리 로직 팬일 경우만 작업 가능하도록 수정
- Change 3
  - 팬채널 댓글 관련 권한 처리 로직 팬일 경우만 작업 가능하도록 수정

## To reviewers

<!-- 이 PR을 확인 할 Code Reviewer에게 남길 메세지를 작성하세요 -->
