### PR TITLE
✨ feat:#74 관련 리팩토링 브랜치 PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fanmix/api/batch/CustomTransactionManager.java
+++ b/src/main/java/com/fanmix/api/batch/CustomTransactionManager.java
@@ -1,0 +1,18 @@
+package com.fanmix.api.batch;
+
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
+
+@Component
+public class CustomTransactionManager extends JpaTransactionManager {
+
+	@Override
+	protected EntityManager createEntityManagerForTransaction() {
+		EntityManager entityManagerForTransaction = super.createEntityManagerForTransaction();
+		entityManagerForTransaction.setFlushMode(FlushModeType.COMMIT);
+		return entityManagerForTransaction;
+	}
+}

--- a/src/main/java/com/fanmix/api/batch/InfluencerJobConfiguration.java
+++ b/src/main/java/com/fanmix/api/batch/InfluencerJobConfiguration.java
@@ -1,0 +1,25 @@
+package com.fanmix.api.batch;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class InfluencerJobConfiguration {
+
+	private final JobRepository jobRepository;
+
+	@Bean
+	public Job cacheInfluencerJob(Step updateStep, Step insertStep) {
+		return new JobBuilder("cacheInfluencerJob", jobRepository)
+			.start(updateStep)
+			.next(insertStep)
+			.build();
+	}
+}

--- a/src/main/java/com/fanmix/api/batch/InfluencerStepConfiguration.java
+++ b/src/main/java/com/fanmix/api/batch/InfluencerStepConfiguration.java
@@ -16,7 +16,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
-import org.springframework.transaction.PlatformTransactionManager;
 
 import com.fanmix.api.batch.processor.ExistingInfluencerProcessor;
 import com.fanmix.api.batch.processor.NewInfluencerProcessor;
@@ -36,7 +35,7 @@ public class InfluencerStepConfiguration {
 	private static final int CHUNK_SIZE = 30;
 
 	private final JobRepository jobRepository;
-	private final PlatformTransactionManager transactionManager;
+	private final CustomTransactionManager customTransactionManager;
 	private final EntityManagerFactory entityManagerFactory;
 	private final InfluencerRatingCacheRepository influencerRatingCacheRepository;
 	private final InfluencerRepository influencerRepository;
@@ -51,7 +50,7 @@ public class InfluencerStepConfiguration {
 		backOffPolicy.setInitialInterval(1000);
 
 		return new StepBuilder("updateStep", jobRepository)
-			.<InfluencerRatingCache, InfluencerRatingCache>chunk(CHUNK_SIZE, transactionManager)
+			.<InfluencerRatingCache, InfluencerRatingCache>chunk(CHUNK_SIZE, customTransactionManager)
 			.reader(existingInfluencerReader)
 			.processor(existingInfluencerProcessor)
 			.writer(existingInfluencerWriter)
@@ -77,7 +76,7 @@ public class InfluencerStepConfiguration {
 		backOffPolicy.setInitialInterval(1000);
 
 		return new StepBuilder("insertStep", jobRepository)
-			.<Influencer, InfluencerRatingCache>chunk(CHUNK_SIZE, transactionManager)
+			.<Influencer, InfluencerRatingCache>chunk(CHUNK_SIZE, customTransactionManager)
 			.reader(newInfluencerReader)
 			.processor(newInfluencerProcessor)
 			.writer(newInfluencerWriter)

--- a/src/main/java/com/fanmix/api/batch/InfluencerStepConfiguration.java
+++ b/src/main/java/com/fanmix/api/batch/InfluencerStepConfiguration.java
@@ -1,0 +1,138 @@
+package com.fanmix.api.batch;
+
+import java.util.Map;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.fanmix.api.batch.processor.ExistingInfluencerProcessor;
+import com.fanmix.api.batch.processor.NewInfluencerProcessor;
+import com.fanmix.api.domain.influencer.entity.Influencer;
+import com.fanmix.api.domain.influencer.entity.InfluencerRatingCache;
+import com.fanmix.api.domain.influencer.repository.InfluencerRepository;
+import com.fanmix.api.domain.influencer.repository.cache.InfluencerRatingCacheRepository;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class InfluencerStepConfiguration {
+	private static final int CHUNK_SIZE = 30;
+
+	private final JobRepository jobRepository;
+	private final InfluencerRatingCacheRepository influencerRatingCacheRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final EntityManagerFactory entityManagerFactory;
+	private final InfluencerRepository influencerRepository;
+
+	@Bean
+	public Step updateStep(
+		ItemReader<InfluencerRatingCache> existingInfluencerReader,
+		ExistingInfluencerProcessor existingInfluencerProcessor,
+		ItemWriter<InfluencerRatingCache> existingInfluencerWriter
+	) {
+		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+		backOffPolicy.setInitialInterval(1000);
+
+		return new StepBuilder("updateStep", jobRepository)
+			.<InfluencerRatingCache, InfluencerRatingCache>chunk(CHUNK_SIZE, transactionManager)
+			.reader(existingInfluencerReader)
+			.processor(existingInfluencerProcessor)
+			.writer(existingInfluencerWriter)
+
+			// 하다가 오류가 났을때 어떻게 할건지 활성화
+			.faultTolerant()
+			// 일단은 어떤 오류든 3번까지 재시도
+			// Reader 는 retry 지원 안함
+			.retryLimit(3)
+			.retry(Exception.class)
+			// 재시도시 1초 기다렸다가
+			.backOffPolicy(backOffPolicy)
+			.build();
+	}
+
+	@Bean
+	public Step insertStep(
+		RepositoryItemReader<Influencer> newInfluencerReader,
+		NewInfluencerProcessor newInfluencerProcessor,
+		ItemWriter<InfluencerRatingCache> newInfluencerWriter
+	) {
+		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+		backOffPolicy.setInitialInterval(1000);
+
+		return new StepBuilder("insertStep", jobRepository)
+			.<Influencer, InfluencerRatingCache>chunk(CHUNK_SIZE, transactionManager)
+			.reader(newInfluencerReader)
+			.processor(newInfluencerProcessor)
+			.writer(newInfluencerWriter)
+			.faultTolerant()
+			.retryLimit(3)
+			.retry(Exception.class)
+			.backOffPolicy(backOffPolicy)
+			.build();
+	}
+
+	@Bean
+	@StepScope
+	public JpaPagingItemReader<InfluencerRatingCache> existingInfluencerReader(
+		@Value("#{jobParameters['lastInfluencerId']}") Long lastInfluencerId) {
+		return new JpaPagingItemReaderBuilder<InfluencerRatingCache>()
+			.name("jpaPagingItemReader")
+			.entityManagerFactory(entityManagerFactory)
+			.queryString(
+				"SELECT i FROM InfluencerRatingCache i JOIN FETCH i.influencer WHERE i.id <= :lastInfluencerId"
+			)
+			.parameterValues(Map.of("lastInfluencerId", lastInfluencerId))
+			.pageSize(CHUNK_SIZE)
+			.build();
+	}
+
+	@Bean
+	@StepScope
+	public ItemWriter<InfluencerRatingCache> existingInfluencerWriter() {
+
+		return chunk -> log.info("=====Item Writer=====");
+	}
+
+	@Bean
+	@StepScope
+	public RepositoryItemReader<Influencer> newInfluencerReader(
+		@Value("#{jobParameters['lastInfluencerId']}") Long lastInfluencerId) {
+		return new RepositoryItemReaderBuilder<Influencer>()
+			.name("secondStepRepositoryItemReader")
+			.repository(influencerRepository)
+			.methodName("findByIdGreaterThan")
+			.arguments(lastInfluencerId.intValue())
+			.pageSize(CHUNK_SIZE)
+			.sorts(Map.of("id", Sort.Direction.ASC))
+			.build();
+	}
+
+	@Bean
+	@StepScope
+	public ItemWriter<InfluencerRatingCache> newInfluencerWriter() {
+
+		return new JpaItemWriterBuilder<InfluencerRatingCache>()
+			.entityManagerFactory(entityManagerFactory)
+			.usePersist(true)
+			.build();
+	}
+}

--- a/src/main/java/com/fanmix/api/batch/processor/ExistingInfluencerProcessor.java
+++ b/src/main/java/com/fanmix/api/batch/processor/ExistingInfluencerProcessor.java
@@ -1,0 +1,59 @@
+package com.fanmix.api.batch.processor;
+
+import static com.fanmix.api.domain.influencer.entity.AuthenticationStatus.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import com.fanmix.api.domain.influencer.entity.Influencer;
+import com.fanmix.api.domain.influencer.entity.InfluencerRatingCache;
+import com.fanmix.api.domain.influencer.entity.tag.InfluencerTag;
+import com.fanmix.api.domain.influencer.entity.tag.InfluencerTagMapper;
+import com.fanmix.api.domain.influencer.repository.tag.InfluencerTagMapperRepository;
+import com.fanmix.api.domain.review.entity.Review;
+import com.fanmix.api.domain.review.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ExistingInfluencerProcessor implements ItemProcessor<InfluencerRatingCache, InfluencerRatingCache> {
+
+	private final ReviewRepository reviewRepository;
+	private final InfluencerTagMapperRepository influencerTagMapperRepository;
+
+	@Override
+	public InfluencerRatingCache process(InfluencerRatingCache cache) {
+		Influencer influencer = cache.getInfluencer();
+
+		final List<String> tagList = influencerTagMapperRepository.findByInfluencer(influencer)
+			.stream()
+			.map(InfluencerTagMapper::getInfluencerTag)
+			.map(InfluencerTag::getTagName)
+			.toList();
+		final Optional<Review> latestReview =
+			reviewRepository.findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(influencer);
+		LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
+
+		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencerId(influencer.getId()).get(0);
+		double contentsRating = ((BigDecimal)averageRatings[0]).doubleValue();
+		double communicationRating = ((BigDecimal)averageRatings[1]).doubleValue();
+		double trustRating = ((BigDecimal)averageRatings[2]).doubleValue();
+		double averageRating = (contentsRating + communicationRating + trustRating) / 3.0;
+
+		return cache.update(
+			influencer.getInfluencerImageUrl(), influencer.getInfluencerName(),
+			influencer.getAuthenticationStatus().equals(APPROVED),
+			tagList.get(0), tagList.get(1), tagList.get(2),
+			latestReviewDate, averageRating, contentsRating, communicationRating, trustRating,
+			influencer.getTotalViewCount()
+		);
+	}
+}

--- a/src/main/java/com/fanmix/api/batch/processor/NewInfluencerProcessor.java
+++ b/src/main/java/com/fanmix/api/batch/processor/NewInfluencerProcessor.java
@@ -1,0 +1,59 @@
+package com.fanmix.api.batch.processor;
+
+import static com.fanmix.api.domain.influencer.entity.AuthenticationStatus.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import com.fanmix.api.domain.influencer.entity.Influencer;
+import com.fanmix.api.domain.influencer.entity.InfluencerRatingCache;
+import com.fanmix.api.domain.influencer.entity.tag.InfluencerTag;
+import com.fanmix.api.domain.influencer.entity.tag.InfluencerTagMapper;
+import com.fanmix.api.domain.influencer.repository.tag.InfluencerTagMapperRepository;
+import com.fanmix.api.domain.review.entity.Review;
+import com.fanmix.api.domain.review.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class NewInfluencerProcessor implements ItemProcessor<Influencer, InfluencerRatingCache> {
+
+	private final ReviewRepository reviewRepository;
+	private final InfluencerTagMapperRepository influencerTagMapperRepository;
+
+	@Override
+	public InfluencerRatingCache process(Influencer influencer) {
+
+		final List<String> tagList = influencerTagMapperRepository.findByInfluencer(influencer)
+			.stream()
+			.map(InfluencerTagMapper::getInfluencerTag)
+			.map(InfluencerTag::getTagName)
+			.toList();
+		final Optional<Review> latestReview =
+			reviewRepository.findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(influencer);
+		LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
+
+		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencerId(influencer.getId()).get(0);
+		double contentsRating = ((BigDecimal)averageRatings[0]).doubleValue();
+		double communicationRating = ((BigDecimal)averageRatings[1]).doubleValue();
+		double trustRating = ((BigDecimal)averageRatings[2]).doubleValue();
+		double averageRating = (contentsRating + communicationRating + trustRating) / 3.0;
+
+		return InfluencerRatingCache.createInfluencerCache(
+			influencer.getId(), influencer, influencer.getInfluencerImageUrl(), influencer.getInfluencerName(),
+			influencer.getAuthenticationStatus().equals(APPROVED),
+			tagList.get(0), tagList.get(1), tagList.get(2),
+			latestReviewDate, averageRating, contentsRating, communicationRating, trustRating,
+			influencer.getTotalViewCount()
+		);
+	}
+}
+

--- a/src/main/java/com/fanmix/api/common/redis/constants/InfluencerRedisConstants.java
+++ b/src/main/java/com/fanmix/api/common/redis/constants/InfluencerRedisConstants.java
@@ -1,6 +1,10 @@
 package com.fanmix.api.common.redis.constants;
 
-public abstract class InfluencerRedisConstants {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class InfluencerRedisConstants {
 
 	public static final String INFLUENCER_VIEW_REDIS_PREFIX = "influencerView";
 	public static final String INFLUENCER_VIEW_REDIS_VALUE = "viewed";

--- a/src/main/java/com/fanmix/api/domain/influencer/entity/InfluencerRatingCache.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/entity/InfluencerRatingCache.java
@@ -9,8 +9,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
@@ -28,7 +26,6 @@ import lombok.NoArgsConstructor;
 @EntityListeners(AuditingEntityListener.class)
 public class InfluencerRatingCache {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private Integer id;
 
@@ -86,10 +83,11 @@ public class InfluencerRatingCache {
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
-	private InfluencerRatingCache(String influencerImageUrl, String influencerName, Boolean isAuthenticated,
-		String tag1,
-		String tag2, String tag3, LocalDateTime latestReviewDate, Double averageRating, Double contentsRating,
-		Double communicationRating, Double trustRating, Integer totalViewCount, Influencer influencer) {
+	private InfluencerRatingCache(Integer id, String influencerImageUrl, String influencerName, Boolean isAuthenticated,
+		String tag1, String tag2, String tag3, LocalDateTime latestReviewDate, Double averageRating,
+		Double contentsRating, Double communicationRating, Double trustRating, Integer totalViewCount,
+		Influencer influencer) {
+		this.id = id;
 		this.influencerImageUrl = influencerImageUrl;
 		this.influencerName = influencerName;
 		this.isAuthenticated = isAuthenticated;
@@ -105,13 +103,14 @@ public class InfluencerRatingCache {
 		this.influencer = influencer;
 	}
 
-	public static InfluencerRatingCache createInfluencerCache(String influencerImageUrl, String influencerName,
-		Boolean isAuthenticated, String tag1, String tag2, String tag3, LocalDateTime latestReviewDate,
+	public static InfluencerRatingCache createInfluencerCache(Integer influencerId, String influencerImageUrl,
+		String influencerName, Boolean isAuthenticated,
+		String tag1, String tag2, String tag3, LocalDateTime latestReviewDate,
 		Double averageRating, Double contentsRating, Double communicationRating, Double trustRating,
 		Integer totalViewCount, Influencer influencer) {
-		return new InfluencerRatingCache(influencerImageUrl, influencerName, isAuthenticated, tag1, tag2, tag3,
-			latestReviewDate, averageRating, contentsRating, communicationRating, trustRating, totalViewCount,
-			influencer);
+		return new InfluencerRatingCache(influencerId, influencerImageUrl, influencerName, isAuthenticated,
+			tag1, tag2, tag3, latestReviewDate,
+			averageRating, contentsRating, communicationRating, trustRating, totalViewCount, influencer);
 	}
 
 	public void update(String influencerImageUrl, String influencerName, Boolean isAuthenticated, String tag1,

--- a/src/main/java/com/fanmix/api/domain/influencer/entity/InfluencerRatingCache.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/entity/InfluencerRatingCache.java
@@ -83,11 +83,12 @@ public class InfluencerRatingCache {
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
 
-	private InfluencerRatingCache(Integer id, String influencerImageUrl, String influencerName, Boolean isAuthenticated,
+	private InfluencerRatingCache(Integer id, Influencer influencer,
+		String influencerImageUrl, String influencerName, Boolean isAuthenticated,
 		String tag1, String tag2, String tag3, LocalDateTime latestReviewDate, Double averageRating,
-		Double contentsRating, Double communicationRating, Double trustRating, Integer totalViewCount,
-		Influencer influencer) {
+		Double contentsRating, Double communicationRating, Double trustRating, Integer totalViewCount) {
 		this.id = id;
+		this.influencer = influencer;
 		this.influencerImageUrl = influencerImageUrl;
 		this.influencerName = influencerName;
 		this.isAuthenticated = isAuthenticated;
@@ -100,21 +101,21 @@ public class InfluencerRatingCache {
 		this.communicationRating = communicationRating;
 		this.trustRating = trustRating;
 		this.totalViewCount = totalViewCount;
-		this.influencer = influencer;
 	}
 
-	public static InfluencerRatingCache createInfluencerCache(Integer influencerId, String influencerImageUrl,
-		String influencerName, Boolean isAuthenticated,
+	public static InfluencerRatingCache createInfluencerCache(Integer influencerId, Influencer influencer,
+		String influencerImageUrl, String influencerName, Boolean isAuthenticated,
 		String tag1, String tag2, String tag3, LocalDateTime latestReviewDate,
 		Double averageRating, Double contentsRating, Double communicationRating, Double trustRating,
-		Integer totalViewCount, Influencer influencer) {
-		return new InfluencerRatingCache(influencerId, influencerImageUrl, influencerName, isAuthenticated,
+		Integer totalViewCount) {
+		return new InfluencerRatingCache(influencerId, influencer, influencerImageUrl, influencerName, isAuthenticated,
 			tag1, tag2, tag3, latestReviewDate,
-			averageRating, contentsRating, communicationRating, trustRating, totalViewCount, influencer);
+			averageRating, contentsRating, communicationRating, trustRating, totalViewCount);
 	}
 
-	public void update(String influencerImageUrl, String influencerName, Boolean isAuthenticated, String tag1,
-		String tag2, String tag3, LocalDateTime latestReviewDate, Double averageRating, Double contentsRating,
+	public InfluencerRatingCache update(String influencerImageUrl, String influencerName, Boolean isAuthenticated,
+		String tag1, String tag2, String tag3,
+		LocalDateTime latestReviewDate, Double averageRating, Double contentsRating,
 		Double communicationRating, Double trustRating, Integer totalViewCount) {
 		this.influencerImageUrl = influencerImageUrl;
 		this.influencerName = influencerName;
@@ -128,5 +129,6 @@ public class InfluencerRatingCache {
 		this.communicationRating = communicationRating;
 		this.trustRating = trustRating;
 		this.totalViewCount = totalViewCount;
+		return this;
 	}
 }

--- a/src/main/java/com/fanmix/api/domain/influencer/repository/InfluencerRepository.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/repository/InfluencerRepository.java
@@ -24,4 +24,5 @@ public interface InfluencerRepository extends JpaRepository<Influencer, Integer>
 
 	Slice<Influencer> findAllByOrderByWeeklyViewCountDesc(Pageable pageable);
 
+	Slice<Influencer> findByIdGreaterThan(Integer lastInfluencerId, Pageable pageable);
 }

--- a/src/main/java/com/fanmix/api/domain/influencer/repository/cache/InfluencerRatingCacheRepository.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/repository/cache/InfluencerRatingCacheRepository.java
@@ -1,7 +1,10 @@
 package com.fanmix.api.domain.influencer.repository.cache;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +15,9 @@ public interface InfluencerRatingCacheRepository
 
 	@EntityGraph(attributePaths = "influencer")
 	List<InfluencerRatingCache> findAll();
+
+	Optional<InfluencerRatingCache> findFirstByOrderByIdDesc();
+
+	@EntityGraph(attributePaths = "influencer")
+	Slice<InfluencerRatingCache> findByIdLessThanEqual(Integer lastInfluencerId, Pageable pageable);
 }

--- a/src/main/java/com/fanmix/api/domain/influencer/service/InfluencerScheduledService.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/service/InfluencerScheduledService.java
@@ -1,12 +1,15 @@
 package com.fanmix.api.domain.influencer.service;
 
-import static com.fanmix.api.domain.influencer.entity.AuthenticationStatus.*;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -17,13 +20,8 @@ import com.fanmix.api.common.redis.constants.InfluencerRedisConstants;
 import com.fanmix.api.domain.influencer.dto.response.InfluencerResponseDto;
 import com.fanmix.api.domain.influencer.entity.Influencer;
 import com.fanmix.api.domain.influencer.entity.InfluencerRatingCache;
-import com.fanmix.api.domain.influencer.entity.tag.InfluencerTag;
-import com.fanmix.api.domain.influencer.entity.tag.InfluencerTagMapper;
 import com.fanmix.api.domain.influencer.repository.InfluencerRepository;
 import com.fanmix.api.domain.influencer.repository.cache.InfluencerRatingCacheRepository;
-import com.fanmix.api.domain.influencer.repository.tag.InfluencerTagMapperRepository;
-import com.fanmix.api.domain.review.entity.Review;
-import com.fanmix.api.domain.review.repository.ReviewRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,88 +29,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InfluencerScheduledService {
 
-	public record InfluencerCacheDataRecord(
-		String influencerImageUrl,
-		String influencerName,
-		boolean isAuthenticated,
-		String[] tags,
-		LocalDateTime latestReviewDate,
-		double averageRating,
-		double contentsRating,
-		double communicationRating,
-		double trustRating,
-		int totalViewCount
-	) {
-	}
-
 	private final InfluencerRepository influencerRepository;
 	private final InfluencerRatingCacheRepository influencerRatingCacheRepository;
-	private final ReviewRepository reviewRepository;
-	private final InfluencerTagMapperRepository influencerTagMapperRepository;
 	private final RedisService redisService;
 
-	@Transactional
-	@Scheduled(cron = "0 0 * * * *")
-	public void updateInfluencerRating() {
-		List<InfluencerRatingCache> influencerCacheList = influencerRatingCacheRepository.findAll();
-		LocalDateTime lastUpdateDateTime = (influencerCacheList.isEmpty())
-			? LocalDateTime.of(2000, 1, 1, 0, 0, 0)
-			: influencerCacheList.get(influencerCacheList.size() - 1).getUpdatedAt();
-		List<Influencer> newInfluencerList = influencerRepository.findAllByCrDateAfter(lastUpdateDateTime);
-
-		// 기존 캐시들 업데이트
-		for (InfluencerRatingCache influencerCache : influencerCacheList) {
-			InfluencerCacheDataRecord cacheData = createCacheDataRecord(influencerCache.getInfluencer());
-			influencerCache.update(cacheData.influencerImageUrl(), cacheData.influencerName(),
-				cacheData.isAuthenticated(),
-				cacheData.tags()[0], cacheData.tags()[1], cacheData.tags()[2],
-				cacheData.latestReviewDate(), cacheData.averageRating(),
-				cacheData.contentsRating(), cacheData.communicationRating(),
-				cacheData.trustRating(), cacheData.totalViewCount);
-		}
-
-		// 마지막 캐시 업데이트 이후 생성된 인플루언서 데이터도 캐시로
-		for (Influencer influencer : newInfluencerList) {
-			InfluencerCacheDataRecord cacheData = createCacheDataRecord(influencer);
-			influencerRatingCacheRepository.save(
-				InfluencerRatingCache.createInfluencerCache(cacheData.influencerImageUrl(),
-					cacheData.influencerName(), cacheData.isAuthenticated(),
-					cacheData.tags()[0], cacheData.tags()[1], cacheData.tags()[2],
-					cacheData.latestReviewDate(), cacheData.averageRating(),
-					cacheData.contentsRating(), cacheData.communicationRating(),
-					cacheData.trustRating(), cacheData.totalViewCount, influencer)
-			);
-		}
-	}
-
-	private InfluencerCacheDataRecord createCacheDataRecord(Influencer influencer) {
-		boolean isAuthenticated = influencer.getAuthenticationStatus().equals(APPROVED);
-
-		final List<String> tagList = influencerTagMapperRepository.findByInfluencer(influencer)
-			.stream()
-			.map(InfluencerTagMapper::getInfluencerTag)
-			.map(InfluencerTag::getTagName)
-			.toList();
-
-		String[] tags = new String[3];
-		for (int i = 0; i < Math.min(tagList.size(), 3); i++) {
-			tags[i] = tagList.get(i);
-		}
-
-		final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedOrderByCrDateDesc(
-			influencer, false);
-		LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
-
-		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencer(influencer.getId()).get(0);
-		double contentsRating = ((BigDecimal)averageRatings[0]).doubleValue();
-		double communicationRating = ((BigDecimal)averageRatings[1]).doubleValue();
-		double trustRating = ((BigDecimal)averageRatings[2]).doubleValue();
-		double averageRating = (contentsRating + communicationRating + trustRating) / 3.0;
-
-		return new InfluencerCacheDataRecord(influencer.getInfluencerImageUrl(), influencer.getInfluencerName(),
-			isAuthenticated, tags, latestReviewDate, averageRating,
-			contentsRating, communicationRating, trustRating, influencer.getTotalViewCount());
-	}
+	private final JobLauncher jobLauncher;
+	private final Job cacheInfluencerJob;
 
 	@Scheduled(cron = "0 59 23 * * SAT")
 	@Transactional
@@ -128,5 +50,26 @@ public class InfluencerScheduledService {
 		List<Influencer> all = influencerRepository.findAll();
 
 		all.forEach(Influencer::initializeWeeklyViewCount);
+	}
+
+	@Scheduled(cron = "0 0 * * * *")
+	public void updateInfluencerRatingCache() throws
+		JobInstanceAlreadyCompleteException,
+		JobExecutionAlreadyRunningException,
+		JobParametersInvalidException,
+		JobRestartException {
+		Optional<InfluencerRatingCache> lastCacheInfluencer =
+			influencerRatingCacheRepository.findFirstByOrderByIdDesc();
+
+		int parameter = (lastCacheInfluencer.isPresent())
+			? lastCacheInfluencer.get().getInfluencer().getId()
+			: 0;
+
+		jobLauncher.run(cacheInfluencerJob,
+			new JobParametersBuilder()
+				//.getNextJobParameters(cacheInfluencerJob)
+				.addLong("lastInfluencerId", (long)parameter, false)
+				.addLong("run.id", System.currentTimeMillis())
+				.toJobParameters());
 	}
 }

--- a/src/main/java/com/fanmix/api/domain/influencer/service/InfluencerService.java
+++ b/src/main/java/com/fanmix/api/domain/influencer/service/InfluencerService.java
@@ -76,11 +76,11 @@ public class InfluencerService {
 			.map(InfluencerTag::getTagName)
 			.toList();
 
-		final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedOrderByCrDateDesc(
-			influencer, false);
+		final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(
+			influencer);
 		LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
 
-		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencer(influencer.getId()).get(0);
+		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencerId(influencer.getId()).get(0);
 		Long totalReviewCount = reviewRepository.countByInfluencerAndIsDeleted(influencer, false);
 
 		boolean isFollowing = false;
@@ -130,11 +130,11 @@ public class InfluencerService {
 			.map(InfluencerTag::getTagName)
 			.toList();
 
-		final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedOrderByCrDateDesc(
-			influencer, false);
+		final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(
+			influencer);
 		LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
 
-		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencer(influencer.getId()).get(0);
+		Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencerId(influencer.getId()).get(0);
 		Long totalReviewCount = reviewRepository.countByInfluencerAndIsDeleted(influencer, false);
 
 		boolean isFollowing = false;

--- a/src/main/java/com/fanmix/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/fanmix/api/domain/member/service/MemberService.java
@@ -396,13 +396,13 @@ public class MemberService implements UserDetailsService {
 				log.debug("인플루언서의 팬채널id : " + fanChannelId);
 
 				//해당 인플루언서의 최신 리뷰
-				final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedOrderByCrDateDesc(
-					influencer, false);
+				final Optional<Review> latestReview = reviewRepository.findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(
+					influencer);
 				LocalDateTime latestReviewDate = latestReview.map(Review::getCrDate).orElse(null);
 				log.debug("인플루언서에 딸린 최신 리뷰 : " + latestReviewDate);
 
 				//나의 리뷰가 아니라 모든 리뷰어들중에 최신의 리뷰만 반영해야한다.
-				Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencer(influencer.getId()).get(0);
+				Object[] averageRatings = reviewRepository.findAverageRatingsByInfluencerId(influencer.getId()).get(0);
 				double contentsRating = ((BigDecimal)averageRatings[0]).doubleValue();
 				double communicationRating = ((BigDecimal)averageRatings[1]).doubleValue();
 				double trustRating = ((BigDecimal)averageRatings[2]).doubleValue();

--- a/src/main/java/com/fanmix/api/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fanmix/api/domain/review/repository/ReviewRepository.java
@@ -15,7 +15,7 @@ import com.fanmix.api.domain.member.entity.Member;
 import com.fanmix.api.domain.review.entity.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQuerydslRepository {
-	Optional<Review> findFirstByInfluencerAndIsDeletedOrderByCrDateDesc(Influencer influencer, Boolean isDeleted);
+	Optional<Review> findFirstByInfluencerAndIsDeletedFalseOrderByCrDateDesc(Influencer influencer);
 
 	//findTopBy는 전체결과를 가져온다음 필터를 걸고 첫번째 행을 반환
 	Optional<Review> findTopByMemberAndInfluencerAndIsDeletedOrderByCrDateDesc(Member member, Influencer influencer,
@@ -45,7 +45,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
 		+ "AND r.cr_date = latest_reviews.latest_date "
 		+ "WHERE r.influencer_id = :influencerId "
 		+ "AND r.is_deleted = false", nativeQuery = true)
-	List<Object[]> findAverageRatingsByInfluencer(Integer influencerId);
+	List<Object[]> findAverageRatingsByInfluencerId(Integer influencerId);
 
 	Long countByInfluencerAndIsDeleted(Influencer influencer, Boolean isDeleted);
 


### PR DESCRIPTION
## Motivation

#74 이슈에 적힌대로
인플루언서 검색용 테이블 업데이트 작업을 Spring Batch 적용해 리팩토링

JpaPagingItemReader,
RepositoryItemReader,
RepositoryItemReader + CustomTransactionManager

세가지 방법으로 리팩토링 하고
첫번째 방법은 문제가 있어 폐기
두번째 방법은 하이버네이트 배치 적용 불가로
세번째 방법을 적용하였고
하이버네이트 배치 적용을 위한 Application 파일 내에 변동사항이 있다.

## Key Changes

- Change 1
  - 2adeb550b80898a122621828a21912a41510318b: build.gradle에 Spring Batch 관련 dependency 추가 
- Change 2
  - eecccb01ed43b00056bb54c663c4a64f1176c7b6: InfluencerRatingCache의 Id 전략 Auto Increment -> Influencer Entity와 동일하게 직접 적용
- Change 3
  - 350abf140976bcf9087d49a9ed1c7533e48dcb5f, dc755695d08225aa003ecfb1b7f5e6c11872860e, cb103f60b7ab9023bde1936bd1469dbcf682e1e0: 인플루언서 검색용 테이블 업데이트 작업을 Spring Batch 적용해 리팩토링
## To reviewers
관련 내용을 블로그에 정리했습니다.

https://velog.io/@zoomin3022/FANMIX-%EC%9D%B8%ED%94%8C%EB%A3%A8%EC%96%B8%EC%84%9C-%EC%B0%BE%EA%B8%B0-%EA%B8%B0%EB%8A%A5-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94-1.-%ED%85%8C%EC%9D%B4%EB%B8%94-%EB%B6%84%EB%A6%AC

