### PR TITLE
🚑 !HOTFIX: CustomTransactionManager 생성에 따른 TransactionManagerConfig 추가

### DIFF
--- a/src/main/java/com/fanmix/api/common/conf/TransactionManagerConfig.java
+++ b/src/main/java/com/fanmix/api/common/conf/TransactionManagerConfig.java
@@ -1,0 +1,34 @@
+package com.fanmix.api.common.conf;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.fanmix.api.batch.CustomTransactionManager;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class TransactionManagerConfig {
+
+	private final EntityManagerFactory entityManagerFactory;
+
+	// 기본으로 PlatformTransactionManager 찾을때는 JpaTransactionManager
+	@Primary
+	@Bean
+	public PlatformTransactionManager transactionManager() {
+		return new JpaTransactionManager(entityManagerFactory);
+	}
+
+	// 커스텀 트랜잭션 매니저 빈 등록 얘는 타입을 CustomTransactionManager 로 di 할 때만
+	@Bean(name = "customTransactionManager")
+	public CustomTransactionManager customTransactionManager() {
+		CustomTransactionManager customTransactionManager = new CustomTransactionManager();
+		customTransactionManager.setEntityManagerFactory(entityManagerFactory);
+		return customTransactionManager;
+	}
+}


### PR DESCRIPTION
## Motivation
이슈로 따로 빼서 정리하고 해당 이슈를 커밋메시지에 넣는 방식으로 했어야 됐지만 
급하게 처리하는 바람에 이렇게 PR에 남깁니다.

상황은 #83 이후
Transactional 어노테이션을 사용한 메서드를 쓸 때
> No bean named 'transactionManager' available: No matching TransactionManager bean found for qualifier 'transactionManager' - neither qualifier match nor bean name match!

이런 에러가 발생
이 이유로는 Spring Boot는 JpaTransactionManager를 자동으로 구성할 때
```java
	@Bean
	@ConditionalOnMissingBean(TransactionManager.class)
	public PlatformTransactionManager transactionManager(
			ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers) {
		JpaTransactionManager transactionManager = new JpaTransactionManager();
		transactionManagerCustomizers
			.ifAvailable((customizers) -> customizers.customize((TransactionManager) transactionManager));
		return transactionManager;
	}
```
TransactionManager 타입의 빈이 이미 Spring 컨텍스트에 존재하지 않을 때만 
자동으로 JpaTransactionManager를 빈으로 등록합니다.

그래서 CustomTransactionManager를 만들면서 기본으로 등록되던 JpaTransactionManager가 등록되지 않았고
transactionManager라는 이름을 가진 PlatformTransactionManager 빈을 찾을 때 
customTransactionManager 라는 이름을 가진 PlatformTransactionManager 빈 밖에 없으므로 빈을 찾을 수 없다는 에러발생

CustomTransactionManager는 배치 파일에서만 사용하므로 TransactionManagerConfig 파일을 만들고
JpaTransactionManager을 생성하는 메서드를 Primary 어노테이션을 사용한 빈으로 등록하고

CustomTransactionManager는 사용할 때 명시적으로
CustomTransactionManager customTransactionManager 이런식으로 di 받게 적용했습니다.
